### PR TITLE
Fix: Include TypeScript declaration files in npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,7 @@
 .github/
 test/
+*.ts
+*.map
+.vscode/
+node_modules/
+tsconfig.json

--- a/package.json
+++ b/package.json
@@ -14,8 +14,16 @@
   "bin": {
     "json-diff": "./bin/json-diff"
   },
+  "files": [
+    "dist/index.js",
+    "dist/index.d.ts",
+    "dist/lib",
+    "bin"
+  ],
   "scripts": {
+    "clean": "rm -rf dist",
     "build": "tsc",
+    "prepublishOnly": "npm run clean && npm run build",
     "test:build": "tsc && cp -R test/fixtures dist/test/fixtures",
     "test": "tsx --test --enable-source-maps --import @power-assert/node test/*.test.ts",
     "test:ci": "npm run test:build && node --test dist/test/*.test.js"


### PR DESCRIPTION
This pull request fixes an issue where TypeScript declaration (.d.ts) files were missing from the published npm package.
