### PR TITLE
Configurable array diff algorithms with CLI options	

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ temp/
 
 # Build output
 dist/
+
+# test output
+test-results/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/paulownia/node-json-diff/actions/workflows/ci.yml/badge.svg)](https://github.com/paulownia/node-json-diff/actions/workflows/ci.yml)
 
-A command-line tool to compare JSON files and show differences in a unified diff format.
+A command-line tool to compare JSON files and show differences.
 
 ## Installation
 
@@ -17,6 +17,33 @@ npm install -g @paulownia/json-diff
 ```bash
 json-diff file1.json file2.json
 ```
+
+### Options
+
+- `--array-diff` (or `-a`): Array diff algorithm (default: `elem`)
+  - `elem`: Compare arrays element by element. Arrays must have the same length for detailed comparison
+  - `lcs`: Use Myers algorithm (Longest Common Subsequence) for array comparison
+  - `set`: Treat arrays as sets, ignoring element order
+
+#### Array Diff Algorithms
+
+**elem (Element-wise comparison):**
+```bash
+json-diff file1.json file2.json --array-diff elem
+```
+This is the default behavior. Arrays are compared element by element at the same index. If arrays have different lengths, they are treated as completely different.
+
+**lcs (Myers algorithm):**
+```bash
+json-diff file1.json file2.json --array-diff lcs
+```
+Uses the Myers algorithm to find the longest common subsequence. This provides standard diff output showing additions and deletions.
+
+**set (Set comparison):**
+```bash
+json-diff file1.json file2.json --array-diff set
+```
+Treats arrays as sets, ignoring the order of elements. Only shows elements that exist in one array but not the other.
 
 ### Example
 

--- a/bin/json-diff
+++ b/bin/json-diff
@@ -1,22 +1,26 @@
 #!/usr/bin/env node
 
 import { printJsonFilesDiff } from '../dist/index.js';
+import { parseCliOptions } from '../dist/lib/cli-options.js';
 
 /**
  * entry point
  */
-function main(file1, file2) {
-  if (!file1 || !file2) {
-    console.error('Usage: json-diff <file1.json> <file2.json>');
+function main() {
+  let options;
+  try {
+    options = parseCliOptions(process.argv.slice(2));
+  } catch (error) {
+    console.error('Usage: json-diff <file1.json> <file2.json> [--array-diff|-a <elem|lcs|set>]');
     process.exit(1);
   }
 
   try {
-    printJsonFilesDiff(file1, file2);
+    printJsonFilesDiff(options.file1, options.file2, { arrayDiffAlgorithm: options.arrayDiff });
   } catch (error) {
     console.error(`Error: ${error.message}`);
     process.exit(1);
   }
 }
 
-main(process.argv[2], process.argv[3]);
+main();

--- a/bin/json-diff
+++ b/bin/json-diff
@@ -36,7 +36,7 @@ function main() {
       process.exit(1);
     }
 
-    printJsonFilesDiff(main.file1, main.file2, { arrayDiffAlgorithm: main.arrayDiff });
+    printJsonFilesDiff(out, main.file1, main.file2, { arrayDiffAlgorithm: main.arrayDiff });
 
   } catch (error) {
     if (error instanceof TypeError) { // TypeError for invalid arguments

--- a/bin/json-diff
+++ b/bin/json-diff
@@ -1,24 +1,49 @@
 #!/usr/bin/env node
 
 import { printJsonFilesDiff } from '../dist/index.js';
-import { parseCliOptions } from '../dist/lib/cli-options.js';
+import { parseCliOptions, printUsage, printVersion } from '../dist/lib/cli-options.js';
+import { Writable } from 'node:stream';
+
+const out = new Writable({
+  write(chunk, encoding, callback) {
+    process.stdout.write(chunk, encoding);
+    process.stdout.write('\n');
+    callback();
+  },
+});
 
 /**
  * entry point
  */
 function main() {
-  let options;
   try {
-    options = parseCliOptions(process.argv.slice(2));
-  } catch (error) {
-    console.error('Usage: json-diff <file1.json> <file2.json> [--array-diff|-a <elem|lcs|set>]');
-    process.exit(1);
-  }
+    const {
+      main,
+      help,
+      version,
+    } = parseCliOptions(process.argv.slice(2));
 
-  try {
-    printJsonFilesDiff(options.file1, options.file2, { arrayDiffAlgorithm: options.arrayDiff });
+    if (help) {
+      printUsage(out);
+      return;
+    }
+    if (version) {
+      printVersion(out);
+      return;
+    }
+    if (!main) {
+      printUsage(out);
+      process.exit(1);
+    }
+
+    printJsonFilesDiff(main.file1, main.file2, { arrayDiffAlgorithm: main.arrayDiff });
+
   } catch (error) {
-    console.error(`Error: ${error.message}`);
+    if (error instanceof TypeError) { // TypeError for invalid arguments
+      showUsage(out);
+    } else {
+      process.stderr.write(`Error: ${error instanceof Error ? error.message : error}\n`);
+    }
     process.exit(1);
   }
 }

--- a/lib/cli-options.ts
+++ b/lib/cli-options.ts
@@ -1,0 +1,32 @@
+import yargs from 'yargs';
+import { ArrayDiffAlgorithm } from './types.js';
+
+export interface CliOptions {
+  file1: string;
+  file2: string;
+  arrayDiff: ArrayDiffAlgorithm;
+}
+
+/**
+ * Parse command line options for the JSON diff tool. argv is the command line arguments array.
+ */
+export function parseCliOptions(argv: string[]): CliOptions {
+  const parsed = yargs(argv)
+    .usage('Usage: $0 <file1.json> <file2.json> [options]')
+    .option('array-diff', {
+      alias: 'a',
+      choices: ['elem', 'lcs', 'set'] as const,
+      default: 'elem',
+      describe: 'Array diff algorithm (elem, lcs, set)',
+      type: 'string',
+    })
+    .demandCommand(2)
+    .help(true)
+    .parseSync();
+
+  return {
+    file1: parsed._[0] as string,
+    file2: parsed._[1] as string,
+    arrayDiff: parsed['array-diff'] as ArrayDiffAlgorithm,
+  };
+}

--- a/lib/cli-options.ts
+++ b/lib/cli-options.ts
@@ -1,32 +1,86 @@
-import yargs from 'yargs';
+import { parseArgs } from 'node:util';
 import { ArrayDiffAlgorithm } from './types.js';
+import { readFileSync } from 'node:fs';
+import { Writable } from 'node:stream';
 
 export interface CliOptions {
-  file1: string;
-  file2: string;
-  arrayDiff: ArrayDiffAlgorithm;
+  main?: {
+    file1: string;
+    file2: string;
+    arrayDiff: ArrayDiffAlgorithm;
+  }
+  help?: boolean;
+  version?: boolean;
 }
+
+const options = {
+  'array-diff': {
+    type: 'string',
+    default: 'elem',
+    short: 'a',
+    description: 'Array diff algorithm (elem, lcs, set)',
+  },
+  'help': {
+    type: 'boolean',
+    short: 'h',
+    description: 'Show help',
+  },
+  'version': {
+    type: 'boolean',
+    short: 'v',
+    description: 'Show version',
+  },
+} as const;
 
 /**
  * Parse command line options for the JSON diff tool. argv is the command line arguments array.
  */
-export function parseCliOptions(argv: string[]): CliOptions {
-  const parsed = yargs(argv)
-    .usage('Usage: $0 <file1.json> <file2.json> [options]')
-    .option('array-diff', {
-      alias: 'a',
-      choices: ['elem', 'lcs', 'set'] as const,
-      default: 'elem',
-      describe: 'Array diff algorithm (elem, lcs, set)',
-      type: 'string',
-    })
-    .demandCommand(2)
-    .help(true)
-    .parseSync();
+export function parseCliOptions(args: string[]): CliOptions {
+  const { values, positionals } = parseArgs({
+    args,
+    options,
+    allowPositionals: true,
+  });
+
+  if (values['help']) return { help: true };
+  if (values['version']) return { version: true };
+
+  if (positionals.length !== 2) {
+    throw new TypeError('Exactly two positional arguments are required: <file1> <file2>');
+  }
+  const arrayDiff = values['array-diff'] || 'elem' as ArrayDiffAlgorithm;
+  if (!['elem', 'lcs', 'set'].includes(arrayDiff)) {
+    throw new TypeError(`Invalid array diff algorithm: ${arrayDiff}. Must be one of 'elem', 'lcs', or 'set'.`);
+  }
 
   return {
-    file1: parsed._[0] as string,
-    file2: parsed._[1] as string,
-    arrayDiff: parsed['array-diff'] as ArrayDiffAlgorithm,
+    main: {
+      file1: positionals[0],
+      file2: positionals[1],
+      arrayDiff: (values['array-diff'] || 'elem') as ArrayDiffAlgorithm,
+    },
   };
+}
+
+export function printVersion(writer: Writable) {
+  const packageJson = loadPackageJson();
+  writer.write(packageJson.version);
+}
+
+export function printUsage(writer: Writable) {
+  writer.write([
+    'Usage: json-diff [options] <file1> <file2>',
+    'Options:',
+    '  -a, --array-diff <algorithm>  Array diff algorithm (elem, lcs, set)',
+    '  -h, --help                    Show help',
+    '  -v, --version                 Show version',
+  ].join('\n'));
+}
+
+function loadPackageJson(): { version: string, description: string } {
+  try {
+    return JSON.parse(readFileSync(new URL('../../package.json', import.meta.url), 'utf8')) as { version: string, description: string };
+  } catch (error) {
+    throw new Error('Error reading package.json:', { cause: error });
+  }
 }

--- a/lib/diff-files.ts
+++ b/lib/diff-files.ts
@@ -1,5 +1,6 @@
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
+import { Writable } from 'node:stream';
 import chalk from 'chalk';
 import { diffJsonValues } from './diff.js';
 import { toPathJqQuery } from './path-utils.js';
@@ -11,25 +12,25 @@ export function diffJsonFiles(file1: string, file2: string, options: DiffOptions
   return diffJsonValues(json1, json2, [], options);
 }
 
-export function printJsonFilesDiff(file1: string, file2: string, options: DiffOptions = { arrayDiffAlgorithm: 'elem' }): void {
+export function printJsonFilesDiff(out: Writable, file1: string, file2: string, options: DiffOptions = { arrayDiffAlgorithm: 'elem' }): void {
   try {
-    /* eslint-disable no-console */
+
     const diffList = diffJsonFiles(file1, file2, options);
 
-    console.log(chalk.cyan(`--- ${file1}`));
-    console.log(chalk.cyan(`+++ ${file2}`));
+    out.write(chalk.cyan(`--- ${file1}`));
+    out.write(chalk.cyan(`+++ ${file2}`));
 
     for (const diffItem of diffList) {
-      console.log(`@ ${toPathJqQuery(diffItem.path)} (${diffItem.type})`);
+      out.write(`@ ${toPathJqQuery(diffItem.path)} (${diffItem.type})`);
 
       if (diffItem.lhs !== undefined) {
-        console.log(chalk.red(`  - ${JSON.stringify(diffItem.lhs, null, 0)}`));
+        out.write(chalk.red(`  - ${JSON.stringify(diffItem.lhs, null, 0)}`));
       }
       if (diffItem.rhs !== undefined) {
-        console.log(chalk.green(`  + ${JSON.stringify(diffItem.rhs, null, 0)}`));
+        out.write(chalk.green(`  + ${JSON.stringify(diffItem.rhs, null, 0)}`));
       }
     }
-    /* eslint-enable no-console */
+
   } catch (e) {
     if (e instanceof SyntaxError) {
       throw new Error(`Not a valid JSON file: ${e.message}`);

--- a/lib/diff-files.ts
+++ b/lib/diff-files.ts
@@ -3,18 +3,18 @@ import path from 'path';
 import chalk from 'chalk';
 import { diffJsonValues } from './diff.js';
 import { toPathJqQuery } from './path-utils.js';
-import { DiffItem } from './types.js';
+import { DiffItem, DiffOptions } from './types.js';
 
-export function diffJsonFiles(file1: string, file2: string): DiffItem[] {
+export function diffJsonFiles(file1: string, file2: string, options: DiffOptions = { arrayDiffAlgorithm: 'elem' }): DiffItem[] {
   const json1 = JSON.parse(fs.readFileSync(path.resolve(file1), 'utf8'));
   const json2 = JSON.parse(fs.readFileSync(path.resolve(file2), 'utf8'));
-  return diffJsonValues(json1, json2);
+  return diffJsonValues(json1, json2, [], options);
 }
 
-export function printJsonFilesDiff(file1: string, file2: string): void {
+export function printJsonFilesDiff(file1: string, file2: string, options: DiffOptions = { arrayDiffAlgorithm: 'elem' }): void {
   try {
     /* eslint-disable no-console */
-    const diffList = diffJsonFiles(file1, file2);
+    const diffList = diffJsonFiles(file1, file2, options);
 
     console.log(chalk.cyan(`--- ${file1}`));
     console.log(chalk.cyan(`+++ ${file2}`));

--- a/lib/diff.ts
+++ b/lib/diff.ts
@@ -1,5 +1,7 @@
 // JSON diff logic
-import { JsonValue, DiffItem, isJsonPrimitive, JsonObject , JsonArray } from './types.js';
+import { JsonValue, DiffItem, isJsonPrimitive, JsonObject , JsonArray, DiffOptions } from './types.js';
+import fastArrayDiff from 'fast-array-diff';
+import deepEqual from 'deep-equal';
 /**
  * Create a diff between two JSON values
  */
@@ -7,6 +9,7 @@ export function diffJsonValues(
   left: JsonValue,
   right: JsonValue,
   pathArray: (string | number)[] = [],
+  options: DiffOptions = { arrayDiffAlgorithm: 'elem' },
 ): DiffItem[] {
   // Exclude the case where both are null
   if (left === null && right === null) {
@@ -48,7 +51,7 @@ export function diffJsonValues(
 
   // if both are arrays
   if (Array.isArray(left) && Array.isArray(right)) {
-    return diffJsonArrays(left, right, pathArray);
+    return diffJsonArrays(left, right, pathArray, options);
   }
 
   // if both are not arrays, but one is an array
@@ -62,7 +65,7 @@ export function diffJsonValues(
   }
 
   // At this point, both are guaranteed to be objects
-  return diffJsonObjects(left, right, pathArray);
+  return diffJsonObjects(left, right, pathArray, options);
 }
 
 /**
@@ -72,27 +75,21 @@ function diffJsonArrays(
   left: JsonArray,
   right: JsonArray,
   pathArray: (string | number)[],
+  options: DiffOptions = { arrayDiffAlgorithm: 'elem' },
 ): DiffItem[] {
-  // compare length, if they are different, not compare each element
-  if (left.length !== right.length) {
-    return [{
-      path: pathArray,
-      lhs: left,
-      rhs: right,
-      type: 'modified',
-    }];
+  if (left.length === 0 && right.length === 0) {
+    return []; // no difference
   }
 
-  // compare each element
-  const diffs: DiffItem[] = [];
-  for (let i = 0; i < left.length; i++) {
-    const leftItem = left[i] as JsonValue;
-    const rightItem = right[i] as JsonValue;
-    const elementDiffs = diffJsonValues(leftItem, rightItem, [...pathArray, i]);
-    diffs.push(...elementDiffs);
+  if (options.arrayDiffAlgorithm === 'lcs') {
+    return diffJsonArrayByMyers(left, right, pathArray);
   }
 
-  return diffs;
+  if (options.arrayDiffAlgorithm === 'set') {
+    return diffJsonArraysIgnoringOrder(left, right, pathArray);
+  }
+
+  return diffJsonArraysBasic(left, right, pathArray, options);
 }
 
 /**
@@ -102,6 +99,7 @@ function diffJsonObjects(
   left: JsonObject,
   right: JsonObject,
   pathArray: (string | number)[],
+  options: DiffOptions = { arrayDiffAlgorithm: 'elem' },
 ): DiffItem[] {
   // Compare object keys
   const diffs: DiffItem[] = [];
@@ -119,8 +117,10 @@ function diffJsonObjects(
         type: 'deleted',
       });
     } else {
+      const leftValue = left[key] as JsonValue;
+      const rightValue = right[key] as JsonValue;
       // the key exists in both objects, compare them as json values
-      const elementDiffs = diffJsonValues(left[key] as JsonValue, right[key] as JsonValue, [...pathArray, key]);
+      const elementDiffs = diffJsonValues(leftValue, rightValue, [...pathArray, key], options);
       diffs.push(...elementDiffs);
     }
   }
@@ -135,6 +135,142 @@ function diffJsonObjects(
         type: 'added',
       });
     }
+  }
+  return diffs;
+}
+
+/**
+ * Create a diff between two JSON Arrays.
+ *
+ * This is useful when:
+ * - Each element of the arrays is a object.
+ * - The length of the two arrays is guaranteed to be the same.
+ * - The arrays are already sorted.
+ * This way provides detailed differences for each element.
+ */
+function diffJsonArraysBasic(
+  left: JsonArray,
+  right: JsonArray,
+  pathArray: (string | number)[],
+  options: DiffOptions = { arrayDiffAlgorithm: 'elem' },
+): DiffItem[] {
+  // compare length, if they are different, not compare each element
+  if (left.length !== right.length) {
+    return [{
+      path: pathArray,
+      lhs: left,
+      rhs: right,
+      type: 'modified',
+    }];
+  }
+
+  // compare each element
+  const diffs: DiffItem[] = [];
+  for (let i = 0; i < left.length; i++) {
+    const leftItem = left[i] as JsonValue;
+    const rightItem = right[i] as JsonValue;
+    const elementDiffs = diffJsonValues(leftItem, rightItem, [...pathArray, i], options);
+    diffs.push(...elementDiffs);
+  }
+
+  return diffs;
+}
+
+/**
+ * Make a diff between two JSON arrays using Myers algorithm.
+ *
+ * This is the most standard way. But for object arrays, you will not get detailed differences.
+ */
+function diffJsonArrayByMyers(
+  left: unknown[],
+  right: unknown[],
+  pathArray: (string | number)[] = [],
+): DiffItem[] {
+  const faDiff = fastArrayDiff.diff(left, right, (left, right) => deepEqual(left, right));
+  // copy pathArray to avoid mutation
+  const path = [...pathArray];
+
+  const diffs: DiffItem[] = [];
+  if (faDiff.removed.length > 0) {
+    diffs.push({
+      type: 'deleted',
+      lhs: [...faDiff.removed],
+      rhs: undefined,
+      path,
+    });
+  }
+  if (faDiff.added.length > 0) {
+    diffs.push({
+      type: 'added',
+      lhs: undefined,
+      rhs: [...faDiff.added],
+      path,
+    });
+  }
+  return diffs;
+}
+
+/**
+ * Make a diff between two JSON arrays ignoring the order of elements.
+ *
+ * This is useful when the order of elements in arrays does not matter.
+ * Two JSON arrays are treated like sets, and the symmetric difference is calculated as the diff.
+ * For object arrays, this way does not provide detailed differences.
+ */
+function diffJsonArraysIgnoringOrder(
+  left: unknown[],
+  right: unknown[],
+  pathArray: (string | number)[] = [],
+): DiffItem[] {
+  // If both arrays are empty, return no diff
+  if (left.length === 0 && right.length === 0) {
+    return [];
+  }
+  // elements exist only in left
+  const leftOnly = [];
+  const rightOnly = [];
+  const intersectedRightIndex = new Set<number>();
+
+  out: for (let l = 0; l < left.length; l++) {
+    for (let r = 0; r < right.length; r++) {
+      if (deepEqual(left[l], right[r])) {
+        // lItem exists in right, so skip it
+        intersectedRightIndex.add(r);
+        continue out;
+      }
+    }
+    leftOnly.push(left[l]);
+  }
+
+  // elements exist only in right
+  for (let r = 0; r < right.length; r++) {
+    if (intersectedRightIndex.has(r)) {
+      continue;  // we already found this item in left
+    }
+    for (let l = 0; l < left.length; l++) {
+      if (deepEqual(right[r], left[l])) {
+        continue; // this item exists in left, so skip it
+      }
+    }
+    rightOnly.push(right[r]);
+  }
+
+  const diffs: DiffItem[] = [];
+  if (leftOnly.length > 0) {
+    diffs.push({
+      type: 'deleted',
+      lhs: leftOnly,
+      rhs: undefined,
+      path: pathArray,
+    });
+  }
+  if (rightOnly.length > 0) {
+    diffs.push({
+      type: 'added',
+      lhs: undefined,
+      rhs: rightOnly,
+      path: pathArray,
+    });
   }
   return diffs;
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -5,6 +5,12 @@ export type DiffItem = {
   type: string;
 };
 
+export type ArrayDiffAlgorithm = 'lcs' | 'set' | 'elem';
+
+export type DiffOptions = {
+  arrayDiffAlgorithm: ArrayDiffAlgorithm;
+};
+
 export type JsonNull = null;
 
 export type JsonPrimitive = string | number | boolean;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
-        "chalk": "^5.4.1"
+        "chalk": "^5.4.1",
+        "fast-array-diff": "^1.1.0"
       },
       "bin": {
         "json-diff": "bin/json-diff"
@@ -1548,6 +1549,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/fast-array-diff": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-array-diff/-/fast-array-diff-1.1.0.tgz",
+      "integrity": "sha512-muSPyZa/yHCoDQhah9th57AmLENB1nekbrUoLAqOpQXdl1Kw8VbH24Syl5XLscaQJlx7KRU95bfTDPvVB5BJvw==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.4.1",
+        "deep-equal": "^2.2.3",
         "fast-array-diff": "^1.1.0"
       },
       "bin": {
@@ -19,6 +20,7 @@
         "@eslint/js": "^9.31.0",
         "@power-assert/node": "^0.6.0",
         "@stylistic/eslint-plugin": "^5.2.0",
+        "@types/deep-equal": "^1.0.4",
         "@types/eslint__js": "^8.42.3",
         "@types/node": "^24.0.15",
         "eslint": "^9.31.0",
@@ -800,6 +802,13 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/@types/deep-equal": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@types/deep-equal/-/deep-equal-1.0.4.tgz",
+      "integrity": "sha512-tqdiS4otQP4KmY0PR3u6KbZ5EWvhNdUoS/jc93UuK23C220lOZ/9TvjfxdPcKvqwwDVtmtSCrnr0p/2dirAxkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/eslint": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
@@ -1176,6 +1185,22 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/astring": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/astring/-/astring-1.9.0.tgz",
@@ -1184,6 +1209,21 @@
       "license": "MIT",
       "bin": {
         "astring": "bin/astring"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/balanced-match": {
@@ -1215,6 +1255,53 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/callsites": {
@@ -1306,12 +1393,142 @@
         }
       }
     },
+    "node_modules/deep-equal": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
+      "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.0",
+        "call-bind": "^1.0.5",
+        "es-get-iterator": "^1.1.3",
+        "get-intrinsic": "^1.2.2",
+        "is-arguments": "^1.1.1",
+        "is-array-buffer": "^3.0.2",
+        "is-date-object": "^1.0.5",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.2",
+        "isarray": "^2.0.5",
+        "object-is": "^1.1.5",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.4",
+        "regexp.prototype.flags": "^1.5.1",
+        "side-channel": "^1.0.4",
+        "which-boxed-primitive": "^1.0.2",
+        "which-collection": "^1.0.1",
+        "which-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-get-iterator": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
+      "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "has-symbols": "^1.0.3",
+        "is-arguments": "^1.1.1",
+        "is-map": "^2.0.2",
+        "is-set": "^2.0.2",
+        "is-string": "^1.0.7",
+        "isarray": "^2.0.5",
+        "stop-iteration-iterator": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.25.7",
@@ -1681,6 +1898,21 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1694,6 +1926,61 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-tsconfig": {
@@ -1735,12 +2022,36 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graphemer": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/has-bigints": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -1750,6 +2061,57 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/ignore": {
@@ -1789,6 +2151,112 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/internal-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-arguments": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -1812,6 +2280,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -1821,6 +2301,134 @@
       "engines": {
         "node": ">=0.12.0"
       }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-string": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -1910,6 +2518,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -1982,6 +2599,63 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-is": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -2079,6 +2753,15 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -2119,6 +2802,26 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -2175,6 +2878,23 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/semver": {
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
@@ -2186,6 +2906,38 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/shebang-command": {
@@ -2211,6 +2963,78 @@
         "node": ">=8"
       }
     },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
@@ -2219,6 +3043,19 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/strip-json-comments": {
@@ -2375,6 +3212,64 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
+      "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/word-wrap": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,7 @@
         "@types/yargs": "^17.0.33",
         "chalk": "^5.4.1",
         "deep-equal": "^2.2.3",
-        "fast-array-diff": "^1.1.0",
-        "yargs": "^18.0.0"
+        "fast-array-diff": "^1.1.0"
       },
       "bin": {
         "json-diff": "bin/json-diff"
@@ -1179,18 +1178,6 @@
         "node": ">=0.4.2"
       }
     },
-    "node_modules/ansi-regex": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -1355,20 +1342,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/cliui": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
-      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^7.2.0",
-        "strip-ansi": "^7.1.0",
-        "wrap-ansi": "^9.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1523,12 +1496,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/emoji-regex": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
-      "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
-      "license": "MIT"
-    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -1619,15 +1586,6 @@
         "@esbuild/win32-arm64": "0.25.7",
         "@esbuild/win32-ia32": "0.25.7",
         "@esbuild/win32-x64": "0.25.7"
-      }
-    },
-    "node_modules/escalade": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
-      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -2002,27 +1960,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-caller-file": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "license": "ISC",
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/get-east-asian-width": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.3.0.tgz",
-      "integrity": "sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-intrinsic": {
@@ -3137,38 +3074,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/string-width": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -3391,70 +3296,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/wrap-ansi": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.0.tgz",
-      "integrity": "sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.2.1",
-        "string-width": "^7.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/ansi-styles": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/y18n": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/yargs": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
-      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^9.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "string-width": "^7.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^22.0.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=23"
-      }
-    },
-    "node_modules/yargs-parser": {
-      "version": "22.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
-      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
-      "license": "ISC",
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=23"
       }
     },
     "node_modules/yocto-queue": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,11 @@
       "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
+        "@types/yargs": "^17.0.33",
         "chalk": "^5.4.1",
         "deep-equal": "^2.2.3",
-        "fast-array-diff": "^1.1.0"
+        "fast-array-diff": "^1.1.0",
+        "yargs": "^18.0.0"
       },
       "bin": {
         "json-diff": "bin/json-diff"
@@ -854,6 +856,21 @@
         "undici-types": "~7.8.0"
       }
     },
+    "node_modules/@types/yargs": {
+      "version": "17.0.33",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
+      "integrity": "sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+      "license": "MIT"
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.37.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.37.0.tgz",
@@ -1162,6 +1179,18 @@
         "node": ">=0.4.2"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -1326,6 +1355,20 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1480,6 +1523,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/emoji-regex": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
+      "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
+      "license": "MIT"
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -1570,6 +1619,15 @@
         "@esbuild/win32-arm64": "0.25.7",
         "@esbuild/win32-ia32": "0.25.7",
         "@esbuild/win32-x64": "0.25.7"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -1944,6 +2002,27 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.3.0.tgz",
+      "integrity": "sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-intrinsic": {
@@ -3058,6 +3137,38 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -3280,6 +3391,70 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.0.tgz",
+      "integrity": "sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -50,9 +50,11 @@
   },
   "homepage": "https://github.com/paulownia/node-json-diff#readme",
   "dependencies": {
+    "@types/yargs": "^17.0.33",
     "chalk": "^5.4.1",
     "deep-equal": "^2.2.3",
-    "fast-array-diff": "^1.1.0"
+    "fast-array-diff": "^1.1.0",
+    "yargs": "^18.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
   },
   "homepage": "https://github.com/paulownia/node-json-diff#readme",
   "dependencies": {
-    "chalk": "^5.4.1"
+    "chalk": "^5.4.1",
+    "fast-array-diff": "^1.1.0"
   },
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   "homepage": "https://github.com/paulownia/node-json-diff#readme",
   "dependencies": {
     "chalk": "^5.4.1",
+    "deep-equal": "^2.2.3",
     "fast-array-diff": "^1.1.0"
   },
   "publishConfig": {
@@ -60,6 +61,7 @@
     "@eslint/js": "^9.31.0",
     "@power-assert/node": "^0.6.0",
     "@stylistic/eslint-plugin": "^5.2.0",
+    "@types/deep-equal": "^1.0.4",
     "@types/eslint__js": "^8.42.3",
     "@types/node": "^24.0.15",
     "eslint": "^9.31.0",

--- a/package.json
+++ b/package.json
@@ -53,8 +53,7 @@
     "@types/yargs": "^17.0.33",
     "chalk": "^5.4.1",
     "deep-equal": "^2.2.3",
-    "fast-array-diff": "^1.1.0",
-    "yargs": "^18.0.0"
+    "fast-array-diff": "^1.1.0"
   },
   "publishConfig": {
     "access": "public"

--- a/test/diffJsonArrays.test.ts
+++ b/test/diffJsonArrays.test.ts
@@ -1,0 +1,84 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert';
+import { diffJsonValues } from '../index.js';
+
+describe('diffJsonArrays', () => {
+  const leftArray = [1, 2, 3, 5, 8];
+  const rightArray = [2, 3, 6, 7, 8];
+  const rightArrayUnsorted = [8, 7, 2, 6, 3];
+
+  test('should make a diff between two sorted arrays by lcs', () => {
+    const result = diffJsonValues(leftArray, rightArray, [], { arrayDiffAlgorithm: 'lcs' });
+    assert.strictEqual(result.length, 2);
+
+    assert.strictEqual(result[0].type, 'deleted');
+    assert.deepStrictEqual(result[0].path, []);
+    assert.deepStrictEqual(result[0].lhs, [1, 5]);
+    assert.deepStrictEqual(result[0].rhs, undefined);
+
+    assert.strictEqual(result[1].type, 'added');
+    assert.deepStrictEqual(result[1].path, []);
+    assert.deepStrictEqual(result[1].lhs, undefined);
+    assert.deepStrictEqual(result[1].rhs, [6, 7]);
+  });
+
+  test('should make a diff between a sorted array and an unsorted array by lcs', () => {
+    const result = diffJsonValues(leftArray, rightArrayUnsorted, [], { arrayDiffAlgorithm: 'lcs' });
+    assert.strictEqual(result.length, 2);
+
+    assert.strictEqual(result[0].type, 'deleted');
+    assert.deepStrictEqual(result[0].path, []);
+    assert.deepStrictEqual(result[0].lhs, [1, 5, 8]);
+    assert.deepStrictEqual(result[0].rhs, undefined);
+
+    assert.strictEqual(result[1].type, 'added');
+    assert.deepStrictEqual(result[1].path, []);
+    assert.deepStrictEqual(result[1].lhs, undefined);
+    assert.deepStrictEqual(result[1].rhs, [8, 7, 6]);
+  });
+
+  test('should make a diff between two sorted arrays by set', () => {
+    const result = diffJsonValues(leftArray, rightArray, [], { arrayDiffAlgorithm: 'set' });
+    assert.strictEqual(result.length, 2);
+
+    assert.strictEqual(result[0].type, 'deleted');
+    assert.deepStrictEqual(result[0].path, []);
+    assertIsArrayAndContainsAll(result[0].lhs, [1, 5]);
+    assert.deepStrictEqual(result[0].rhs, undefined);
+
+    assert.strictEqual(result[1].type, 'added');
+    assert.deepStrictEqual(result[1].path, []);
+    assert.deepStrictEqual(result[1].lhs, undefined);
+    assertIsArrayAndContainsAll(result[1].rhs, [6, 7]);
+  });
+
+  test('should make a diff between a sorted array and an unsorted array by set', () => {
+    const result = diffJsonValues(leftArray, rightArrayUnsorted, [], { arrayDiffAlgorithm: 'set' });
+    assert.strictEqual(result.length, 2);
+
+    assert.strictEqual(result[0].type, 'deleted');
+    assert.deepStrictEqual(result[0].path, []);
+    assertIsArrayAndContainsAll(result[0].lhs, [1, 5]);
+    assert.deepStrictEqual(result[0].rhs, undefined);
+
+    assert.strictEqual(result[1].type, 'added');
+    assert.deepStrictEqual(result[1].path, []);
+    assert.deepStrictEqual(result[1].lhs, undefined);
+    assertIsArrayAndContainsAll(result[1].rhs, [7, 6]);
+  });
+});
+
+/**
+ * Assert that the actual value is an array and contains all expected values.
+ * The order of elements in the actual and expected arrays does not matter.
+ */
+function assertIsArrayAndContainsAll(actual: unknown, expected: unknown[]) {
+  if (!Array.isArray(actual)) {
+    assert.fail(`Expected an array but got ${typeof actual}`);
+  }
+  assert.strictEqual(actual.length, expected.length, `Expected array length to be ${expected.length} but got ${actual.length}`);
+
+  for (const value of expected) {
+    assert(actual.includes(value), `Expected array to contain ${value} but it does not`);
+  }
+}

--- a/test/diffJsonFiles.test.ts
+++ b/test/diffJsonFiles.test.ts
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 import { printJsonFilesDiff } from '../index.js';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
+import { ArrayWritable, nullWritable } from './utils/writable.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -20,7 +21,9 @@ describe('printJsonFilesDiff', () => {
     console.log = (...args: unknown[]) => logs.push(args.map(String).join(' '));
 
     try {
-      printJsonFilesDiff(leftFile, rightFile);
+      const logs: string[] = [];
+      const arrayWritable = new ArrayWritable(logs);
+      printJsonFilesDiff(arrayWritable, leftFile, rightFile);
 
       // Verify that output was generated
       assert(logs.length > 0, 'Should generate output');
@@ -46,7 +49,7 @@ describe('printJsonFilesDiff', () => {
     const rightFile = path.join(__dirname, 'fixtures', 'simple-right.json');
 
     assert.throws(() => {
-      printJsonFilesDiff(leftFile, rightFile);
+      printJsonFilesDiff(nullWritable, leftFile, rightFile);
     }, /File not found/);
   });
 
@@ -60,7 +63,7 @@ describe('printJsonFilesDiff', () => {
       const rightFile = path.join(__dirname, 'fixtures', 'simple-right.json');
 
       assert.throws(() => {
-        printJsonFilesDiff(invalidJsonPath, rightFile);
+        printJsonFilesDiff(nullWritable, invalidJsonPath, rightFile);
       }, /Not a valid JSON file/);
 
     } finally {

--- a/test/parseCliOption.test.ts
+++ b/test/parseCliOption.test.ts
@@ -1,0 +1,164 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert';
+import { parseCliOptions } from '../lib/cli-options.js';
+
+describe('parseCliOptions', () => {
+  test('should parse basic file arguments', () => {
+    const result = parseCliOptions(['file1.json', 'file2.json']);
+
+    assert.deepStrictEqual(result, {
+      main: {
+        file1: 'file1.json',
+        file2: 'file2.json',
+        arrayDiff: 'elem',
+      },
+    });
+  });
+
+  test('should return help flag when -h is provided', () => {
+    const result = parseCliOptions(['-h']);
+
+    assert.deepStrictEqual(result, {
+      help: true,
+    });
+  });
+
+  test('should return help flag when --help is provided', () => {
+    const result = parseCliOptions(['--help']);
+
+    assert.deepStrictEqual(result, {
+      help: true,
+    });
+  });
+
+  test('should return version flag when -v is provided', () => {
+    const result = parseCliOptions(['-v']);
+
+    assert.deepStrictEqual(result, {
+      version: true,
+    });
+  });
+
+  test('should return version flag when --version is provided', () => {
+    const result = parseCliOptions(['--version']);
+
+    assert.deepStrictEqual(result, {
+      version: true,
+    });
+  });
+
+  test('should parse array-diff option with short flag', () => {
+    const result = parseCliOptions(['-a', 'lcs', 'file1.json', 'file2.json']);
+
+    assert.deepStrictEqual(result, {
+      main: {
+        file1: 'file1.json',
+        file2: 'file2.json',
+        arrayDiff: 'lcs',
+      },
+    });
+  });
+
+  test('should parse array-diff option with long flag', () => {
+    const result = parseCliOptions(['--array-diff', 'set', 'file1.json', 'file2.json']);
+
+    assert.deepStrictEqual(result, {
+      main: {
+        file1: 'file1.json',
+        file2: 'file2.json',
+        arrayDiff: 'set',
+      },
+    });
+  });
+
+  test('should use default array-diff algorithm when not specified', () => {
+    const result = parseCliOptions(['file1.json', 'file2.json']);
+
+    assert.strictEqual(result.main?.arrayDiff, 'elem');
+  });
+
+  test('should throw error when less than 2 files are provided', () => {
+    assert.throws(() => {
+      parseCliOptions(['file1.json']);
+    }, {
+      name: 'TypeError',
+      message: 'Exactly two positional arguments are required: <file1> <file2>',
+    });
+  });
+
+  test('should throw error when no files are provided', () => {
+    assert.throws(() => {
+      parseCliOptions([]);
+    }, {
+      name: 'TypeError',
+      message: 'Exactly two positional arguments are required: <file1> <file2>',
+    });
+  });
+
+  test('should throw error for invalid array-diff algorithm', () => {
+    assert.throws(() => {
+      parseCliOptions(['--array-diff', 'invalid', 'file1.json', 'file2.json']);
+    }, {
+      name: 'TypeError',
+      message: 'Invalid array diff algorithm: invalid. Must be one of \'elem\', \'lcs\', or \'set\'.',
+    });
+  });
+
+  test('should accept all valid array-diff algorithms', () => {
+    const algorithms = ['elem', 'lcs', 'set'];
+
+    algorithms.forEach(algorithm => {
+      const result = parseCliOptions(['--array-diff', algorithm, 'file1.json', 'file2.json']);
+      assert.strictEqual(result.main?.arrayDiff, algorithm);
+    });
+  });
+
+  test('should throw error when more than 2 files are provided', () => {
+    assert.throws(() => {
+      parseCliOptions(['file1.json', 'file2.json', 'extra.json']);
+    }, {
+      name: 'TypeError',
+      message: 'Exactly two positional arguments are required: <file1> <file2>',
+    });
+  });
+
+  test('should prioritize help over other options', () => {
+    const result = parseCliOptions(['--help', '--version', 'file1.json', 'file2.json']);
+
+    assert.deepStrictEqual(result, {
+      help: true,
+    });
+  });
+
+  test('should prioritize version over file arguments but not help', () => {
+    const result = parseCliOptions(['--version', 'file1.json', 'file2.json']);
+
+    assert.deepStrictEqual(result, {
+      version: true,
+    });
+  });
+
+  test('should handle mixed short and long options', () => {
+    const result = parseCliOptions(['-a', 'lcs', 'file1.json', 'file2.json']);
+
+    assert.deepStrictEqual(result, {
+      main: {
+        file1: 'file1.json',
+        file2: 'file2.json',
+        arrayDiff: 'lcs',
+      },
+    });
+  });
+
+  test('should handle options in different positions', () => {
+    const result = parseCliOptions(['file1.json', '--array-diff', 'set', 'file2.json']);
+
+    assert.deepStrictEqual(result, {
+      main: {
+        file1: 'file1.json',
+        file2: 'file2.json',
+        arrayDiff: 'set',
+      },
+    });
+  });
+});

--- a/test/utils/writable.ts
+++ b/test/utils/writable.ts
@@ -1,0 +1,28 @@
+import { Writable } from 'node:stream';
+
+/**
+ * A no-op writable stream that does nothing when data is written to it.
+ */
+export const nullWritable: Writable = new Writable({
+  write(_chunk, _encoding, callback) {
+    callback();
+  },
+});
+
+/**
+ * A writable stream that collects written data into an array.
+ * Useful for testing purposes to capture output.
+ */
+export class ArrayWritable extends Writable {
+  #chunks: string[];
+
+  constructor(store: string[]) {
+    super({ objectMode: true });
+    this.#chunks = store;
+  }
+
+  _write(chunk: string | Buffer, _encoding: string, callback: (error?: Error | null) => void): void {
+    this.#chunks.push(typeof chunk === 'string' ? chunk : chunk.toString());
+    callback();
+  }
+}


### PR DESCRIPTION
This PR adds support for three different array comparison algorithms through the new --array-diff command line option, allowing users to choose the most appropriate method for their use case.