### PR TITLE
fix jq query notataion when the top level of JSON is an array

### DIFF
--- a/lib/path-utils.ts
+++ b/lib/path-utils.ts
@@ -10,9 +10,13 @@ export function toPathJqQuery(pathArray: (string | number)[]): string {
   // [0]   // -> [0]
   if (pathArray.length === 0) return '.';
 
-  return pathArray.map((p) => {
+  return pathArray.map((p, i) => {
     if (typeof p === 'number') {
-      return `[${p}]`;
+      if (i === 0) {
+        return `.[${p}]`; // For the first element, use dot notation for root access
+      } else {
+        return `[${p}]`;
+      }
     }
 
     if (p.includes('.') || p.includes('[') || p.includes(']')) {

--- a/test/toPathJqQuery.test.ts
+++ b/test/toPathJqQuery.test.ts
@@ -40,16 +40,16 @@ describe('toPathJqQuery', () => {
 
   test('should handle root array access', () => {
     const result = toPathJqQuery([0]);
-    assert.strictEqual(result, '[0]');
+    assert.strictEqual(result, '.[0]');
   });
 
   test('should handle multiple array indices', () => {
     const result = toPathJqQuery([0, 1, 2]);
-    assert.strictEqual(result, '[0][1][2]');
+    assert.strictEqual(result, '.[0][1][2]');
   });
 
   test('should handle mixed array and object access', () => {
     const result = toPathJqQuery([0, 'name', 1, 'value']);
-    assert.strictEqual(result, '[0].name[1].value');
+    assert.strictEqual(result, '.[0].name[1].value');
   });
 });


### PR DESCRIPTION
This PR fixes a missing initial . in a JQ query for a JSON comparison with a top-level array