### PR TITLE
 Add JSONC (JSON with Comments) support

### DIFF
--- a/bin/json-diff.ts
+++ b/bin/json-diff.ts
@@ -27,11 +27,18 @@ function main(): void {
       process.exit(1);
     }
 
-    printJsonFilesDiff(process.stdout, main.file1, main.file2, { arrayDiffAlgorithm: main.arrayDiff, arrayKey: main.arrayKey });
+    printJsonFilesDiff(
+      process.stdout,
+      main.file1,
+      main.file2,
+      { arrayDiffAlgorithm: main.arrayDiff, arrayKey: main.arrayKey, acceptJsonc: main.acceptJsonc || false },
+    );
 
   } catch (error: unknown) {
     if (error instanceof TypeError) { // TypeError for invalid arguments
       printUsage(process.stderr);
+    } else if (error instanceof SyntaxError) {
+      process.stderr.write(`Error: Not a valid JSON file: ${error.message}\n`);
     } else {
       process.stderr.write(`Error: ${error instanceof Error ? error.message : error}\n`);
     }

--- a/lib/cli-options.ts
+++ b/lib/cli-options.ts
@@ -8,12 +8,14 @@ export interface CliMainOptions {
   file2: string;
   arrayDiff: ArrayDiffAlgorithm;
   arrayKey?: string;
+  acceptJsonc?: boolean; // Whether to accept JSONC (JSON with comments)
 }
 
 export interface CliOptions {
   main?: CliMainOptions;
   help?: boolean;
   version?: boolean;
+  acceptJsonc?: boolean; // Whether to accept JSONC (JSON with comments)
 }
 
 const options = {
@@ -28,6 +30,11 @@ const options = {
     default: 'id',
     short: 'k',
     description: 'Key field for key-based array comparison (default: id)',
+  },
+  'jsonc': {
+    type: 'boolean',
+    default: false,
+    description: 'Enable JSONC support (comments in JSON)',
   },
   'help': {
     type: 'boolean',
@@ -66,6 +73,7 @@ export function parseCliOptions(args: string[]): CliOptions {
     file1: positionals[0],
     file2: positionals[1],
     arrayDiff,
+    acceptJsonc: values['jsonc'] || false,
   };
 
   if (arrayDiff === 'key') {
@@ -89,6 +97,7 @@ export function printUsage(writer: Writable) {
     '  -k, --array-key <field>       Key field for key-based array comparison (default: id)',
     '  -h, --help                    Show help',
     '  -v, --version                 Show version',
+    '  -c, --jsonc                   Enable JSONC support (comments in JSON)',
   ].join('\n'));
   writer.write('\n');
 }

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -1,0 +1,6 @@
+export class InvalidJsonFileError extends Error {
+  constructor(fileName: string) {
+    super(`Invalid JSON file: ${fileName}`);
+    this.name = 'InvalidJsonFileError';
+  }
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -20,6 +20,10 @@ export type DiffOptions = {
   arrayKey?: string;
 };
 
+export type ParserOptions = {
+  acceptJsonc?: boolean;
+};
+
 export type JsonNull = null;
 
 export type JsonPrimitive = string | number | boolean;

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "chalk": "^5.4.1",
         "deep-equal": "^2.2.3",
-        "fast-array-diff": "^1.1.0"
+        "fast-array-diff": "^1.1.0",
+        "jsonc-parser": "^3.3.1"
       },
       "bin": {
         "json-diff": "dist/bin/json-diff.js"
@@ -2469,6 +2470,12 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
       "license": "MIT"
     },
     "node_modules/keyv": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
   "dependencies": {
     "chalk": "^5.4.1",
     "deep-equal": "^2.2.3",
-    "fast-array-diff": "^1.1.0"
+    "fast-array-diff": "^1.1.0",
+    "jsonc-parser": "^3.3.1"
   },
   "publishConfig": {
     "access": "public"

--- a/test/fixtures/test.jsonc
+++ b/test/fixtures/test.jsonc
@@ -1,0 +1,9 @@
+{
+  // This is a JSONC file with comments
+  "name": "John Doe",
+  "age": 30, // Age in years
+  "city": "New York",
+  /* Multi-line comment
+     describing hobbies */
+  "hobbies": ["reading", "coding"]
+}

--- a/test/fixtures/test2.jsonc
+++ b/test/fixtures/test2.jsonc
@@ -1,0 +1,8 @@
+{
+  // This is another JSONC file with comments
+  "name": "Jane Smith",
+  "age": 25, // Different age
+  "city": "San Francisco",
+  /* Different hobbies */
+  "hobbies": ["swimming", "painting"]
+}

--- a/test/parseCliOption.test.ts
+++ b/test/parseCliOption.test.ts
@@ -11,6 +11,7 @@ describe('parseCliOptions', () => {
         file1: 'file1.json',
         file2: 'file2.json',
         arrayDiff: 'elem',
+        acceptJsonc: false,
       },
     });
   });
@@ -55,6 +56,7 @@ describe('parseCliOptions', () => {
         file1: 'file1.json',
         file2: 'file2.json',
         arrayDiff: 'lcs',
+        acceptJsonc: false,
       },
     });
   });
@@ -67,6 +69,7 @@ describe('parseCliOptions', () => {
         file1: 'file1.json',
         file2: 'file2.json',
         arrayDiff: 'set',
+        acceptJsonc: false,
       },
     });
   });
@@ -110,6 +113,7 @@ describe('parseCliOptions', () => {
     algorithms.forEach(algorithm => {
       const result = parseCliOptions(['--array-diff', algorithm, 'file1.json', 'file2.json']);
       assert.strictEqual(result.main?.arrayDiff, algorithm);
+      assert.strictEqual(result.main?.acceptJsonc, false);
     });
   });
 
@@ -130,8 +134,24 @@ describe('parseCliOptions', () => {
     });
   });
 
+  test('should prioritize help over jsonc option', () => {
+    const result = parseCliOptions(['--help', '--jsonc', 'file1.jsonc', 'file2.jsonc']);
+
+    assert.deepStrictEqual(result, {
+      help: true,
+    });
+  });
+
   test('should prioritize version over file arguments but not help', () => {
     const result = parseCliOptions(['--version', 'file1.json', 'file2.json']);
+
+    assert.deepStrictEqual(result, {
+      version: true,
+    });
+  });
+
+  test('should prioritize version over jsonc option but not help', () => {
+    const result = parseCliOptions(['--version', '--jsonc', 'file1.jsonc', 'file2.jsonc']);
 
     assert.deepStrictEqual(result, {
       version: true,
@@ -146,6 +166,7 @@ describe('parseCliOptions', () => {
         file1: 'file1.json',
         file2: 'file2.json',
         arrayDiff: 'lcs',
+        acceptJsonc: false,
       },
     });
   });
@@ -158,6 +179,52 @@ describe('parseCliOptions', () => {
         file1: 'file1.json',
         file2: 'file2.json',
         arrayDiff: 'set',
+        acceptJsonc: false,
+      },
+    });
+  });
+
+  test('should parse jsonc option with long flag', () => {
+    const result = parseCliOptions(['--jsonc', 'file1.jsonc', 'file2.jsonc']);
+
+    assert.deepStrictEqual(result, {
+      main: {
+        file1: 'file1.jsonc',
+        file2: 'file2.jsonc',
+        arrayDiff: 'elem',
+        acceptJsonc: true,
+      },
+    });
+  });
+
+  test('should default acceptJsonc to false when not specified', () => {
+    const result = parseCliOptions(['file1.json', 'file2.json']);
+
+    assert.strictEqual(result.main?.acceptJsonc, false);
+  });
+
+  test('should handle jsonc option with other options', () => {
+    const result = parseCliOptions(['--jsonc', '--array-diff', 'lcs', 'file1.jsonc', 'file2.jsonc']);
+
+    assert.deepStrictEqual(result, {
+      main: {
+        file1: 'file1.jsonc',
+        file2: 'file2.jsonc',
+        arrayDiff: 'lcs',
+        acceptJsonc: true,
+      },
+    });
+  });
+
+  test('should handle jsonc option in different positions', () => {
+    const result = parseCliOptions(['file1.jsonc', '--jsonc', 'file2.jsonc']);
+
+    assert.deepStrictEqual(result, {
+      main: {
+        file1: 'file1.jsonc',
+        file2: 'file2.jsonc',
+        arrayDiff: 'elem',
+        acceptJsonc: true,
       },
     });
   });


### PR DESCRIPTION
Added --jsonc option to support JSONC files (JSON with comments), allowing diff comparison of commented JSON files, which are often used in configuration files.