### PR TITLE
Add color control options  with environment variable support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,28 @@ json-diff file1.json file2.json
   - `set`: Treat arrays as sets, ignoring element order
   - `key`: Compare arrays of objects by matching them using a unique identifier field
 - `--array-key` (or `-k`): Key field for key-based array comparison (default: `id`). Only used with `--array-diff key`
+- `--color` (or `-c`): Force color output even when piped or redirected to a file
+- `--no-color`: Disable color output completely
+- `--help` (or `-h`): Show help message
+- `--version` (or `-v`): Show version number
+
+#### Color Output
+
+By default, colors are automatically enabled for terminal output and disabled when output is piped or redirected. You can override this behavior:
+
+```bash
+# Force colors even when redirecting to a file
+json-diff --color file1.json file2.json > diff.txt
+
+# Disable colors completely
+json-diff --no-color file1.json file2.json
+```
+
+You can also control colors using environment variables:
+- `FORCE_COLOR=1`: Force color output (set to `0` to disable) - compatible with chalk library
+- `NO_COLOR=1`: Disable color output (any value disables colors) - follows NO_COLOR standard
+
+Priority: CLI options > NO_COLOR > FORCE_COLOR > Automatic detection
 
 #### Array Diff Algorithms
 
@@ -134,12 +156,12 @@ Compare two JSON files and output the differences to console.
 - `file1` (string): Path to the first JSON file
 - `file2` (string): Path to the second JSON file
 
-### `diffJsonFiles(json1, json2)`
+### `diffJsonFiles(file1, file2)`
 
 Compare two JSON files and return the differences as an array.
 
-- `json1` (any): First JSON object
-- `json2` (any): Second JSON object
+- `file1` (string): Path to the first JSON file
+- `file2` (string): Path to the second JSON file
 - Returns: Array of difference objects
 
 ### `diffJsonValues(json1, json2)`

--- a/bin/json-diff.ts
+++ b/bin/json-diff.ts
@@ -31,7 +31,12 @@ function main(): void {
       process.stdout,
       main.file1,
       main.file2,
-      { arrayDiffAlgorithm: main.arrayDiff, arrayKey: main.arrayKey, acceptJsonc: main.acceptJsonc || false },
+      {
+        arrayDiffAlgorithm: main.arrayDiff,
+        arrayKey: main.arrayKey,
+        acceptJsonc: main.acceptJsonc,
+        color: main.color,
+      },
     );
 
   } catch (error: unknown) {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,6 +1,6 @@
 import js from '@eslint/js';
-import tseslint from 'typescript-eslint';
 import stylistic from '@stylistic/eslint-plugin';
+import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
   {
@@ -34,7 +34,9 @@ export default tseslint.config(
 
       // Stylistic rules
       '@stylistic/semi': 'error',
+      '@stylistic/semi-spacing': 'error',
       '@stylistic/comma-dangle': ['error', 'always-multiline'],
+      '@stylistic/comma-spacing': 'error',
       '@stylistic/quotes': ['error', 'single'],
       '@stylistic/block-spacing': 'error',
       '@stylistic/indent': ['error', 2],
@@ -57,6 +59,10 @@ export default tseslint.config(
         maxEOF: 0,
         maxBOF: 0,
       }],
+      '@stylistic/object-property-newline': ['error', {
+        allowAllPropertiesOnSameLine: true,
+      }],
+      '@stylistic/array-element-newline': ['error', 'consistent'],
     },
   },
   {

--- a/lib/cli-options.ts
+++ b/lib/cli-options.ts
@@ -124,8 +124,11 @@ export function printUsage(writer: Writable) {
     '  -h, --help                    Show help',
     '  -v, --version                 Show version',
     '  -c, --jsonc                   Enable JSONC support (comments in JSON)',
+    'Environment Variables:',
+    '  FORCE_COLOR=1                 Force color output (FORCE_COLOR=0 disables)',
+    '  NO_COLOR=1                    Disable color output (any value disables)',
+    '',
   ].join('\n'));
-  writer.write('\n');
 }
 
 function loadPackageJson(): { version: string, description: string } {

--- a/lib/cli-options.ts
+++ b/lib/cli-options.ts
@@ -9,6 +9,7 @@ export interface CliMainOptions {
   arrayDiff: ArrayDiffAlgorithm;
   arrayKey?: string;
   acceptJsonc?: boolean; // Whether to accept JSONC (JSON with comments)
+  color?: boolean;
 }
 
 export interface CliOptions {
@@ -35,6 +36,15 @@ const options = {
     type: 'boolean',
     default: false,
     description: 'Enable JSONC support (comments in JSON)',
+  },
+  'color': {
+    type: 'boolean',
+    short: 'c',
+    description: 'Force color output even when piped or redirected',
+  },
+  'no-color': {
+    type: 'boolean',
+    description: 'Disable color output',
   },
   'help': {
     type: 'boolean',
@@ -64,6 +74,12 @@ export function parseCliOptions(args: string[]): CliOptions {
   if (positionals.length !== 2) {
     throw new TypeError('Exactly two positional arguments are required: <file1> <file2>');
   }
+
+  // Check for conflicting color options
+  if (values['color'] && values['no-color']) {
+    throw new TypeError('Cannot specify both --color and --no-color options');
+  }
+
   const arrayDiff = values['array-diff'] || 'elem';
   if (!isArrayDiffAlgorithm(arrayDiff)) {
     throw new TypeError(`Invalid array diff algorithm: ${arrayDiff}. Must be one of 'elem', 'lcs', 'set', or 'key'.`);
@@ -80,6 +96,14 @@ export function parseCliOptions(args: string[]): CliOptions {
     main.arrayKey = values['array-key'] || 'id';
   }
 
+  // Handle color options (CLI options take precedence over environment variables)
+  if (values['no-color']) {
+    main.color = false;
+  } else if (values['color']) {
+    main.color = true;
+  }
+  // If neither option is specified, main.color remains undefined and will use environment variables
+
   return { main };
 }
 
@@ -95,6 +119,8 @@ export function printUsage(writer: Writable) {
     'Options:',
     '  -a, --array-diff <algorithm>  Array diff algorithm (elem, lcs, set, key)',
     '  -k, --array-key <field>       Key field for key-based array comparison (default: id)',
+    '  -c, --color                   Force color output even when piped or redirected',
+    '      --no-color                Disable color output',
     '  -h, --help                    Show help',
     '  -v, --version                 Show version',
     '  -c, --jsonc                   Enable JSONC support (comments in JSON)',

--- a/lib/diff-files.ts
+++ b/lib/diff-files.ts
@@ -5,7 +5,28 @@ import path from 'node:path';
 import { Writable } from 'node:stream';
 import { diffJsonValues } from './diff.js';
 import { pathArrayToJqQuery } from './jq-query.js';
-import { DiffItem, DiffOptions, JsonValue, ParserOptions } from './types.js';
+import { DiffItem, DiffOptions, JsonValue, OutputOptions, ParserOptions } from './types.js';
+
+/**
+ * Configure chalk color output based on CLI options and environment variables
+ *
+ * Environment variable support:
+ * - FORCE_COLOR: handled automatically by chalk (FORCE_COLOR=1 enables, FORCE_COLOR=0 disables)
+ * - NO_COLOR: handled manually (chalk doesn't support this standard)
+ *
+ * Priority: CLI options > Environment variables > TTY detection (chalk automatic)
+ */
+export function configureChalkColors(forceColor?: boolean): void {
+  if (forceColor === true) {
+    chalk.level = 3; // Force full color support
+  } else if (forceColor === false) {
+    chalk.level = 0; // Disable all colors
+  } else if (process.env.NO_COLOR) {
+    // NO_COLOR is not supported by chalk, handle it manually
+    chalk.level = 0; // Disable all colors
+  }
+  // Otherwise, use chalk's automatic detection (includes FORCE_COLOR)
+}
 
 export function diffJsonFiles(file1: string, file2: string, options: DiffOptions & ParserOptions = { arrayDiffAlgorithm: 'elem', acceptJsonc: false }): DiffItem[] {
   const parseFunc = options.acceptJsonc ? parseJsonc : JSON.parse;
@@ -34,7 +55,10 @@ export function printJsonFilesDiff(
   out: Writable,
   file1: string,
   file2: string,
-  options: DiffOptions & ParserOptions = { arrayDiffAlgorithm: 'elem', acceptJsonc: false }): void {
+  options: DiffOptions & ParserOptions & OutputOptions = { arrayDiffAlgorithm: 'elem', acceptJsonc: false }): void {
+
+  // Configure colors before printing
+  configureChalkColors(options.color);
 
   const diffList = diffJsonFiles(file1, file2, options);
 

--- a/lib/diff-files.ts
+++ b/lib/diff-files.ts
@@ -28,7 +28,7 @@ export function configureChalkColors(forceColor?: boolean): void {
   // Otherwise, use chalk's automatic detection (includes FORCE_COLOR)
 }
 
-export function diffJsonFiles(file1: string, file2: string, options: DiffOptions & ParserOptions = { arrayDiffAlgorithm: 'elem', acceptJsonc: false }): DiffItem[] {
+export function diffJsonFiles(file1: string, file2: string, options: DiffOptions & ParserOptions = {}): DiffItem[] {
   const parseFunc = options.acceptJsonc ? parseJsonc : JSON.parse;
   const json1 = parseJsonFile(parseFunc, file1);
   const json2 = parseJsonFile(parseFunc, file2);
@@ -55,7 +55,8 @@ export function printJsonFilesDiff(
   out: Writable,
   file1: string,
   file2: string,
-  options: DiffOptions & ParserOptions & OutputOptions = { arrayDiffAlgorithm: 'elem', acceptJsonc: false }): void {
+  options: DiffOptions & ParserOptions & OutputOptions = {},
+): void {
 
   // Configure colors before printing
   configureChalkColors(options.color);

--- a/lib/diff-files.ts
+++ b/lib/diff-files.ts
@@ -47,7 +47,7 @@ function parseJsonFile(parseFunc: (notation: string) => JsonValue, fileName: str
       if (e.code === 'EISDIR') throw new Error(`Expected a file but found a directory: ${e.path}`);
       if (e.code === 'EACCES') throw new Error(`Permission denied: ${e.path}`);
     }
-    throw new Error(`Unexpected error: ${e instanceof Error ? e.message : String(e)}`);;
+    throw new Error(`Unexpected error: ${e instanceof Error ? e.message : String(e)}`);
   }
 }
 

--- a/lib/diff.ts
+++ b/lib/diff.ts
@@ -9,7 +9,7 @@ export function diffJsonValues(
   left: JsonValue,
   right: JsonValue,
   pathArray: PathElement[] = [],
-  options: DiffOptions = { arrayDiffAlgorithm: 'elem' },
+  options: DiffOptions = {},
 ): DiffItem[] {
   // Exclude the case where both are null
   if (left === null && right === null) {
@@ -75,25 +75,22 @@ function diffJsonArrays(
   left: JsonArray,
   right: JsonArray,
   pathArray: PathElement[],
-  options: DiffOptions = { arrayDiffAlgorithm: 'elem' },
+  options: DiffOptions = {},
 ): DiffItem[] {
   if (left.length === 0 && right.length === 0) {
     return []; // no difference
   }
 
-  if (options.arrayDiffAlgorithm === 'lcs') {
-    return diffJsonArrayByMyers(left, right, pathArray);
+  switch (options.arrayDiffAlgorithm) {
+    case 'lcs':
+      return diffJsonArrayByMyers(left, right, pathArray);
+    case 'set':
+      return diffJsonArraysIgnoringOrder(left, right, pathArray);
+    case 'key':
+      return diffJsonArraysByKey(left, right, pathArray, options.arrayKey || 'id', options);
+    default:  // 'elem' or any other value, including undefined
+      return diffJsonArraysBasic(left, right, pathArray, options);
   }
-
-  if (options.arrayDiffAlgorithm === 'set') {
-    return diffJsonArraysIgnoringOrder(left, right, pathArray);
-  }
-
-  if (options.arrayDiffAlgorithm === 'key') {
-    return diffJsonArraysByKey(left, right, pathArray, options.arrayKey || 'id', options);
-  }
-
-  return diffJsonArraysBasic(left, right, pathArray, options);
 }
 
 /**
@@ -103,7 +100,7 @@ function diffJsonObjects(
   left: JsonObject,
   right: JsonObject,
   pathArray: PathElement[],
-  options: DiffOptions = { arrayDiffAlgorithm: 'elem' },
+  options: DiffOptions = {},
 ): DiffItem[] {
   // Compare object keys, filtering out undefined values (JSON doesn't have undefined)
   const diffs: DiffItem[] = [];

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -24,6 +24,10 @@ export type ParserOptions = {
   acceptJsonc?: boolean;
 };
 
+export type OutputOptions = {
+  color?: boolean,
+};
+
 export type JsonNull = null;
 
 export type JsonPrimitive = string | number | boolean;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -16,7 +16,7 @@ export const ArrayDiffAlgorithms = ['lcs', 'set', 'elem', 'key'] as const;
 export type ArrayDiffAlgorithm = typeof ArrayDiffAlgorithms[number];
 
 export type DiffOptions = {
-  arrayDiffAlgorithm: ArrayDiffAlgorithm;
+  arrayDiffAlgorithm?: ArrayDiffAlgorithm;
   arrayKey?: string;
 };
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "test": "tsx --test --enable-source-maps --import @power-assert/node test/*.test.ts",
     "test:ci": "tsc && cp -R test/fixtures dist/test/fixtures && node --test dist/test/*.test.js",
     "lint": "eslint . --ext .js,.ts",
-    "format": "eslint . --ext .js,.ts --fix"
+    "format": "eslint . --ext .js,.ts --fix",
+    "check-type": "tsc --noEmit"
   },
   "keywords": [
     "json",

--- a/test/diffJsonFiles.test.ts
+++ b/test/diffJsonFiles.test.ts
@@ -82,7 +82,7 @@ describe('printJsonFilesDiff', () => {
 
     // Test with acceptJsonc: false (default)
     assert.throws(() => {
-      printJsonFilesDiff(nullWritable, jsoncFile, jsonFile, { arrayDiffAlgorithm: 'elem', acceptJsonc: false });
+      printJsonFilesDiff(nullWritable, jsoncFile, jsonFile, { acceptJsonc: false });
     }, /Not a valid JSON file/);
 
     // Test with no options (defaults to acceptJsonc: false)
@@ -99,7 +99,7 @@ describe('printJsonFilesDiff', () => {
     assert.doesNotThrow(() => {
       const logs: string[] = [];
       const arrayWritable = new ArrayWritable(logs);
-      printJsonFilesDiff(arrayWritable, jsoncFile1, jsoncFile2, { arrayDiffAlgorithm: 'elem', acceptJsonc: true });
+      printJsonFilesDiff(arrayWritable, jsoncFile1, jsoncFile2, { acceptJsonc: true });
 
       // Verify that output was generated
       assert(logs.length > 0, 'Should generate output for JSONC files');
@@ -118,7 +118,7 @@ describe('printJsonFilesDiff', () => {
     const logs: string[] = [];
     const arrayWritable = new ArrayWritable(logs);
 
-    printJsonFilesDiff(arrayWritable, jsoncFile1, jsoncFile2, { arrayDiffAlgorithm: 'elem', acceptJsonc: true });
+    printJsonFilesDiff(arrayWritable, jsoncFile1, jsoncFile2, { acceptJsonc: true });
 
     const output = logs.join('\n');
 

--- a/test/parseCliOption.test.ts
+++ b/test/parseCliOption.test.ts
@@ -228,4 +228,64 @@ describe('parseCliOptions', () => {
       },
     });
   });
+
+  test('should parse color option', () => {
+    const result = parseCliOptions(['--color', 'file1.json', 'file2.json']);
+
+    assert.deepStrictEqual(result, {
+      main: {
+        file1: 'file1.json',
+        file2: 'file2.json',
+        arrayDiff: 'elem',
+        acceptJsonc: false,
+        color: true,
+      },
+    });
+  });
+
+  test('should parse no-color option', () => {
+    const result = parseCliOptions(['--no-color', 'file1.json', 'file2.json']);
+
+    assert.deepStrictEqual(result, {
+      main: {
+        file1: 'file1.json',
+        file2: 'file2.json',
+        arrayDiff: 'elem',
+        acceptJsonc: false,
+        color: false,
+      },
+    });
+  });
+
+  test('should parse short color option', () => {
+    const result = parseCliOptions(['-c', 'file1.json', 'file2.json']);
+
+    assert.deepStrictEqual(result, {
+      main: {
+        file1: 'file1.json',
+        file2: 'file2.json',
+        arrayDiff: 'elem',
+        acceptJsonc: false,
+        color: true,
+      },
+    });
+  });
+
+  test('should throw error when both color and no-color are specified', () => {
+    assert.throws(() => {
+      parseCliOptions(['--color', '--no-color', 'file1.json', 'file2.json']);
+    }, {
+      name: 'TypeError',
+      message: 'Cannot specify both --color and --no-color options',
+    });
+  });
+
+  test('should throw error when both short color and no-color are specified', () => {
+    assert.throws(() => {
+      parseCliOptions(['-c', '--no-color', 'file1.json', 'file2.json']);
+    }, {
+      name: 'TypeError',
+      message: 'Cannot specify both --color and --no-color options',
+    });
+  });
 });


### PR DESCRIPTION
Added comprehensive color control options to provide users with fine-grained control over colored terminal output. This enhancement supports both CLI flags (--color, --no-color) and environment variables (NO_COLOR).