### PR TITLE
Remove test:ci script and simplify test workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,10 @@ jobs:
       run: npm run lint
 
     - name: Run tests
-      run: npm run test:ci
+      run: npm run test
+
+    - name: Build
+      run: npm run build
 
     - name: Test CLI functionality
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,7 @@ jobs:
       run: npm run lint
 
     - name: Run tests
-      run: npm run test
-
-    - name: Build
-      run: npm run build
+      run: npm run test:dist
 
     - name: Test CLI functionality
       run: |

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "build": "tsc && chmod +x dist/bin/json-diff.js",
     "prepublishOnly": "npm run clean && npm run build",
     "test": "tsx --test --enable-source-maps --import @power-assert/node test/*.test.ts",
-    "test:ci": "tsc && cp -R test/fixtures dist/test/fixtures && node --test dist/test/*.test.js",
     "lint": "eslint . --ext .js,.ts",
     "format": "eslint . --ext .js,.ts --fix",
     "check-type": "tsc --noEmit"

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "build": "tsc && chmod +x dist/bin/json-diff.js",
     "prepublishOnly": "npm run clean && npm run build",
     "test": "tsx --test --enable-source-maps --import @power-assert/node test/*.test.ts",
+    "test:dist": "tsc && cp -R test/fixtures dist/test/fixtures && node --test dist/test/*.test.js",
     "lint": "eslint . --ext .js,.ts",
     "format": "eslint . --ext .js,.ts --fix",
     "check-type": "tsc --noEmit"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,6 @@
     "skipLibCheck": true,
     "declaration": true
   },
-  "include": ["lib/**/*.ts", "bin/**/*.ts", "index.ts"],
+  "include": ["lib/**/*.ts", "test/**/*.ts", "bin/**/*.ts", "index.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,6 @@
     "skipLibCheck": true,
     "declaration": true
   },
-  "include": ["lib/**/*.ts", "test/**/*.ts", "bin/**/*.ts", "index.ts"],
+  "include": ["lib/**/*.ts", "bin/**/*.ts", "index.ts"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Summary

- Remove `test:ci` script from package.json (no longer needed)
- Remove `test/**/*.ts` from tsconfig.json include to avoid unnecessary compilation
- Update CI workflow to use `npm run test` and add separate build step

## Background

The `test:ci` script was originally used to run tests against compiled JavaScript files in `dist/`. However, this is redundant because:

1. `npm run test` using `tsx` directly validates TypeScript source
2. The compiled JS output is not distributed (test files are excluded from `files` in package.json)
3. `tsx` and `tsc` produce equivalent runtime behavior for this project